### PR TITLE
Add webhook setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,14 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: superfly/flyctl-actions/setup-flyctl@master
+    - run: flyctl deploy --remote-only
+      env:
+        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.weather.db
+*.sqlite
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install -r requirements.txt
+CMD ["python", "-m", "cat_weather.main"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# cat-weather
+# Cat Weather Bot
+
+Telegram bot for posting weather updates. Requires Python 3.11 and aiogram v3.
+
+The bot stores timezone settings and tracks channels automatically. It works via
+a Telegram webhook.
+
+```bash
+TELEGRAM_TOKEN=... \
+WEBHOOK_URL=https://your-app.fly.dev \
+DB_PATH=weather.db python -m cat_weather.main
+```

--- a/cat_weather/__init__.py
+++ b/cat_weather/__init__.py
@@ -1,0 +1,3 @@
+"""Telegram Weather Bot"""
+
+__all__ = ["main"]

--- a/cat_weather/config.py
+++ b/cat_weather/config.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Config:
+    telegram_token: str
+    webhook_url: str
+    db_path: str = "weather.db"
+    tz_offset: int = 0
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        token = os.environ.get("TELEGRAM_TOKEN")
+        if not token:
+            raise RuntimeError("TELEGRAM_TOKEN is required")
+
+        webhook_url = os.environ.get("WEBHOOK_URL")
+        if not webhook_url:
+            raise RuntimeError("WEBHOOK_URL is required")
+
+        db_path = os.environ.get("DB_PATH", "weather.db")
+        tz_offset = int(os.environ.get("TZ_OFFSET", "0"))
+        return cls(token, webhook_url, db_path, tz_offset)

--- a/cat_weather/database.py
+++ b/cat_weather/database.py
@@ -1,0 +1,61 @@
+import sqlite3
+from typing import Optional
+
+
+class Database:
+    def __init__(self, path: str):
+        self.conn = sqlite3.connect(path)
+        self.conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS superadmins(
+                user_id INTEGER PRIMARY KEY,
+                tz_offset INTEGER DEFAULT 0
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS channels(
+                chat_id INTEGER PRIMARY KEY,
+                title TEXT,
+                added_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+    def set_timezone(self, user_id: int, offset: int) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO superadmins(user_id, tz_offset) VALUES(?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET tz_offset=excluded.tz_offset
+            """,
+            (user_id, offset),
+        )
+        self.conn.commit()
+
+    def get_timezone(self, user_id: int) -> Optional[int]:
+        cur = self.conn.cursor()
+        row = cur.execute(
+            "SELECT tz_offset FROM superadmins WHERE user_id=?", (user_id,)
+        ).fetchone()
+        return row["tz_offset"] if row else None
+
+    def add_channel(self, chat_id: int, title: str) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT OR IGNORE INTO channels(chat_id, title) VALUES(?, ?)",
+            (chat_id, title),
+        )
+        self.conn.commit()
+
+    def remove_channel(self, chat_id: int) -> None:
+        cur = self.conn.cursor()
+        cur.execute("DELETE FROM channels WHERE chat_id=?", (chat_id,))
+        self.conn.commit()

--- a/cat_weather/handlers/__init__.py
+++ b/cat_weather/handlers/__init__.py
@@ -1,0 +1,3 @@
+from . import tz, channels
+
+__all__ = ["tz", "channels"]

--- a/cat_weather/handlers/channels.py
+++ b/cat_weather/handlers/channels.py
@@ -1,0 +1,23 @@
+import logging
+from aiogram import Router
+from aiogram.types import ChatMemberUpdated
+
+from ..database import Database
+
+router = Router()
+logger = logging.getLogger(__name__)
+
+
+@router.my_chat_member()
+async def track_bot_in_chat(event: ChatMemberUpdated) -> None:
+    db: Database = event.bot.get("db")
+    new_status = event.new_chat_member.status
+    old_status = event.old_chat_member.status
+    chat = event.chat
+
+    if new_status in {"administrator", "member"} and old_status == "left":
+        db.add_channel(chat.id, chat.title or "")
+        logger.info("Channel added %s", chat.id)
+    elif new_status == "left":
+        db.remove_channel(chat.id)
+        logger.info("Channel removed %s", chat.id)

--- a/cat_weather/handlers/tz.py
+++ b/cat_weather/handlers/tz.py
@@ -1,0 +1,30 @@
+from aiogram import Router, F
+from aiogram.filters import Command
+from aiogram.types import Message
+
+from ..database import Database
+
+router = Router()
+
+
+@router.message(Command("tz"), F.text)
+async def set_timezone(message: Message) -> None:
+    if not message.from_user:
+        return
+    if not message.text:
+        return
+    parts = message.text.split()
+    if len(parts) != 2:
+        await message.answer("Usage: /tz <offset>")
+        return
+    try:
+        offset = int(parts[1])
+    except ValueError:
+        await message.answer("Offset must be an integer")
+        return
+    if offset < -12 or offset > 14:
+        await message.answer("Offset must be between -12 and 14")
+        return
+    db: Database = message.bot.get("db")
+    db.set_timezone(message.from_user.id, offset)
+    await message.answer(f"Часовой пояс установлен: {offset:+d}")

--- a/cat_weather/main.py
+++ b/cat_weather/main.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+from typing import Any
+
+from aiohttp import web
+from aiogram import Bot, Dispatcher
+
+from .config import Config
+from .database import Database
+
+
+async def ensure_webhook(bot: Bot, base_url: str) -> None:
+    """Make sure Telegram webhook matches base_url."""
+    expected = base_url.rstrip("/") + "/webhook"
+    try:
+        info = await bot.api_request("getWebhookInfo")
+        current = info.get("url", "")
+        if current != expected:
+            await bot.api_request("setWebhook", {"url": expected})
+            logging.info("Webhook registered: %s", expected)
+        else:
+            logging.info("Webhook already registered: %s", expected)
+    except Exception as e:  # pragma: no cover - network errors
+        logging.error("Failed to register webhook: %s", e)
+        raise
+
+
+async def handle_webhook(request: web.Request) -> web.Response:
+    bot: Bot = request.app["bot"]
+    dp: Dispatcher = request.app["dp"]
+    data = await request.json()
+    await dp.feed_webhook_update(bot, data)
+    return web.Response(text="ok")
+
+
+def create_app() -> web.Application:
+    config = Config.from_env()
+    bot = Bot(config.telegram_token)
+    dp = Dispatcher()
+    db = Database(config.db_path)
+    dp["db"] = db
+
+    from .handlers import channels, tz
+    dp.include_router(tz.router)
+    dp.include_router(channels.router)
+
+    app = web.Application()
+    app["bot"] = bot
+    app["dp"] = dp
+    app["config"] = config
+
+    app.router.add_post("/webhook", handle_webhook)
+
+    async def on_startup(app: web.Application) -> None:
+        await bot.start()
+        try:
+            await ensure_webhook(bot, config.webhook_url)
+        except Exception:
+            # ensure_webhook already logged the error
+            raise
+        app["poller"] = asyncio.create_task(dp.start_polling(bot))
+
+    async def on_cleanup(app: web.Application) -> None:
+        app["poller"].cancel()
+        await bot.session.close()
+
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    app = create_app()
+    web.run_app(app, host="0.0.0.0", port=8080)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/architectural_overview.md
+++ b/docs/architectural_overview.md
@@ -245,6 +245,12 @@ Telegram Weather Bot построен по модульному принципу
 • **Ответ бота**: подтверждение установки
 • **Логирование**: INFO начало, SUCCESS или ERROR
 
+### Авто-регистрация каналов
+• **Trigger**: событие `my_chat_member`
+• **Handler**: `handlers.channels.track_bot_in_chat`
+• **DB действия**: добавление/удаление записей в `channels`
+• **Логирование**: INFO добавление или удаление канала
+
 ### `/channels`
 • **Trigger**: команда от суперадмина
 • **Handler**: `handlers.channels.list_channels`
@@ -317,15 +323,13 @@ CMD ["python", "bot.py"]
 
 ### fly.toml
 ```
-app = "telegram-weather-bot"
-primary_region = "waw"
+app = "cat-weather"
+primary_region = "fra"
 [build]
-  image = "python:3.11-slim"
+  dockerfile = "Dockerfile"
 [env]
-  TELEGRAM_TOKEN = "${TELEGRAM_TOKEN}"
-  OPENMETEO_URL = "${OPENMETEO_URL}"
   DB_PATH = "/data/weather.db"
-  TZ_OFFSET = "${TZ_OFFSET}"
+  WEBHOOK_URL = "https://cat-weather.fly.dev"
 ```
 
 ### GitHub Actions — `.github/workflows/deploy.yml`
@@ -349,6 +353,7 @@ jobs:
 - `TELEGRAM_TOKEN` — токен бота
 - `OPENMETEO_URL` — базовый URL сервиса погоды
 - `DB_PATH` — путь к файлу SQLite
+- `WEBHOOK_URL` — публичный адрес приложения
 - `TZ_OFFSET` — часовой пояс по умолчанию
 
 ## 10. Roadmap & Next Steps

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+app = "cat-weather"
+primary_region = "fra"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  DB_PATH = "/data/weather.db"
+
+[mounts]
+  source = "data"
+  destination = "/data"
+
+[experimental]
+  enable_ipv6 = true
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiogram==3.4.1
+aiohttp==3.9.5

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from cat_weather.database import Database
+
+
+def test_timezone_roundtrip(tmp_path):
+    db = Database(tmp_path / "db.sqlite")
+    db.set_timezone(1, 3)
+    assert db.get_timezone(1) == 3

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,52 @@
+import asyncio
+import sys
+import types
+
+# Provide a minimal aiohttp stub so cat_weather.main can be imported
+aiohttp_stub = types.ModuleType("aiohttp")
+aiohttp_stub.web = types.SimpleNamespace(
+    Request=object,
+    Response=object,
+    Application=object,
+)
+sys.modules.setdefault("aiohttp", aiohttp_stub)
+
+aiogram_stub = types.ModuleType("aiogram")
+aiogram_stub.Bot = object
+aiogram_stub.Dispatcher = object
+aiogram_stub.Router = object
+aiogram_stub.F = object
+aiogram_stub.filters = types.SimpleNamespace(Command=object)
+aiogram_stub.types = types.SimpleNamespace(Message=object, ChatMemberUpdated=object)
+sys.modules.setdefault("aiogram", aiogram_stub)
+
+from cat_weather.main import ensure_webhook
+
+
+class DummyBot:
+    def __init__(self, url=""):
+        self.url = url
+        self.calls = []
+
+    async def api_request(self, method: str, data=None):
+        self.calls.append((method, data))
+        if method == "getWebhookInfo":
+            return {"url": self.url}
+        if method == "setWebhook":
+            self.url = data["url"]
+            return True
+        raise NotImplementedError
+
+
+def test_ensure_webhook_registers_when_missing():
+    bot = DummyBot()
+    asyncio.run(ensure_webhook(bot, "https://example.com"))
+    assert bot.url == "https://example.com/webhook"
+    assert ("setWebhook", {"url": "https://example.com/webhook"}) in bot.calls
+
+
+def test_ensure_webhook_no_change():
+    bot = DummyBot("https://example.com/webhook")
+    asyncio.run(ensure_webhook(bot, "https://example.com"))
+    assert bot.url == "https://example.com/webhook"
+    assert len(bot.calls) == 1


### PR DESCRIPTION
## Summary
- add `WEBHOOK_URL` to configuration
- register Telegram webhook during startup
- expose `/webhook` route for updates
- document new environment variable
- cover webhook helper with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c06154ec88332849e582a4975e2b7